### PR TITLE
Add interactive format selection for archive-urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,15 +96,17 @@ npm install
 ### Run
 Place URLs (one per line) in `urls.txt` inside the `url-tool` folder.
 
-Create a merged PDF:
+Create a merged PDF (use `--pdf` to skip the format prompt):
 ```
-node scripts/url-tool/archive-urls.js --output=myfile
+node scripts/url-tool/archive-urls.js --pdf --output=myfile
 ```
 
-Extract page text instead:
+Extract page text instead (use `--markdown` to skip the prompt):
 ```
 node scripts/url-tool/archive-urls.js --markdown --output=pages
 ```
+
+Run without `--pdf` or `--markdown` to choose the format interactively.
 
 # update
 ```

--- a/url-tool/archive-urls.js
+++ b/url-tool/archive-urls.js
@@ -7,7 +7,21 @@ const { default: PDFMerger } = require('pdf-merger-js');
 const args = process.argv.slice(2);
 let outputFileArg = args.find(arg => arg.startsWith('--output='));
 let outputFile = outputFileArg ? outputFileArg.split('=')[1] : null;
-const markdownOnly = args.includes('--markdown');
+let markdownOnly = args.includes('--markdown');
+const pdfFlag = args.includes('--pdf');
+
+if (markdownOnly && pdfFlag) {
+  console.error('❌ Please specify only one of --markdown or --pdf');
+  process.exit(1);
+}
+
+if (!markdownOnly && !pdfFlag) {
+  const resp = readline
+    .question('\nChoose output format - pdf or markdown? [pdf]: ')
+    .trim()
+    .toLowerCase();
+  markdownOnly = resp.startsWith('m');
+}
 
 // === Load URLs from file ===
 const urlFile = 'urls.txt';


### PR DESCRIPTION
## Summary
- allow selecting PDF or Markdown when running `archive-urls.js`
- document the new `--pdf` flag and interactive mode

## Testing
- `node --check url-tool/archive-urls.js`
- `cd url-tool && npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684a50f761e4832192c8d9d41e6b4111